### PR TITLE
Update iOS Info.plist

### DIFF
--- a/BatteryBridge IOS/Info.plist
+++ b/BatteryBridge IOS/Info.plist
@@ -2,13 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSBatteryUsageDescription</key>
-	<string>BatteryBridge needs to monitor battery level to share it with your Mac</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>This app uses Bonjour to discover and connect to your Mac</string>
 	<key>NSBonjourServices</key>
 	<array>
-		<string>_batterybridge._tcp.</string>
+		<string>_batterybridge._tcp</string>
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>


### PR DESCRIPTION
## Summary
- remove the now-unneeded NSBatteryUsageDescription permission
- use `_batterybridge._tcp` in NSBonjourServices to match the code

## Testing
- `swiftc -parse 'BatteryBridge IOS/BatteryBroadcaster.swift' 'BatteryBridge IOS/ContentView.swift' 'BatteryBridge IOS/BatteryBridge_IOSApp.swift'`
- `swiftc -parse BatteryBridge/BatteryBridgeApp.swift BatteryBridge/BatteryBrowser.swift BatteryBridge/ContentView.swift BatteryBridgeConstants.swift`