### PR TITLE
Start scanning sooner

### DIFF
--- a/BatteryBridge/BatteryBridgeApp.swift
+++ b/BatteryBridge/BatteryBridgeApp.swift
@@ -2,7 +2,13 @@ import SwiftUI
 
 @main
 struct BatteryBridgeApp: App {
-    @StateObject private var browser = BatteryBrowser()
+    @StateObject private var browser: BatteryBrowser
+
+    init() {
+        let batteryBrowser = BatteryBrowser()
+        _browser = StateObject(wrappedValue: batteryBrowser)
+        batteryBrowser.startBrowsing()
+    }
     
     var body: some Scene {
         MenuBarExtra {

--- a/BatteryBridge/ContentView.swift
+++ b/BatteryBridge/ContentView.swift
@@ -36,9 +36,6 @@ struct ContentView: View {
         }
         .frame(width: 200)
         .padding()
-        .onAppear {
-            browser.startBrowsing()
-        }
     }
     
     private var batteryIcon: String {


### PR DESCRIPTION
## Summary
- trigger `startBrowsing()` in `BatteryBridgeApp` to scan for devices as soon as the app launches
- remove redundant `onAppear` call from `ContentView`

## Testing
- `git status --short`