### PR TITLE
Add observer cleanup for battery events

### DIFF
--- a/BatteryBridge IOS/BatteryBroadcaster.swift
+++ b/BatteryBridge IOS/BatteryBroadcaster.swift
@@ -157,5 +157,10 @@ class BatteryBroadcaster: ObservableObject {
         broadcastTimer?.invalidate()
         listener?.cancel()
         connections.forEach { $0.cancel() }
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIDevice.batteryLevelDidChangeNotification,
+            object: nil
+        )
     }
 }

--- a/BatteryBridge IOS/ContentView.swift
+++ b/BatteryBridge IOS/ContentView.swift
@@ -4,6 +4,7 @@ import UIKit
 struct ContentView: View {
     @StateObject private var broadcaster = BatteryBroadcaster()
     @State private var actualBatteryLevel: Float = 0.0
+    @State private var batteryObserver: NSObjectProtocol?
     
     var body: some View {
         NavigationStack {
@@ -45,21 +46,31 @@ struct ContentView: View {
             .onAppear {
                 startMonitoring()
             }
+            .onDisappear {
+                stopMonitoring()
+            }
         }
     }
-    
+
     private func startMonitoring() {
         UIDevice.current.isBatteryMonitoringEnabled = true
         updateBatteryLevel()
         broadcaster.startBroadcasting()
-        
+
         // Set up battery monitoring
-        NotificationCenter.default.addObserver(
+        batteryObserver = NotificationCenter.default.addObserver(
             forName: UIDevice.batteryLevelDidChangeNotification,
             object: nil,
             queue: .main
         ) { _ in
             updateBatteryLevel()
+        }
+    }
+
+    private func stopMonitoring() {
+        if let observer = batteryObserver {
+            NotificationCenter.default.removeObserver(observer)
+            batteryObserver = nil
         }
     }
     


### PR DESCRIPTION
## Summary
- clean up battery level observer in iOS ContentView on disappear
- store observer token in view state
- remove notification observer when BatteryBroadcaster is deinitialized

## Testing
- `git status --short`