### PR TITLE
Fix Info.plist path for iOS build

### DIFF
--- a/BatteryBridge.xcodeproj/project.pbxproj
+++ b/BatteryBridge.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 				DEVELOPMENT_TEAM = PPNNAHD8ZD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = "BatteryBridge_IOS/Info.plist";
+                               INFOPLIST_FILE = "BatteryBridge IOS/Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;


### PR DESCRIPTION
## Summary
- correct Info.plist path in project file so the iOS target points to `BatteryBridge IOS/Info.plist` for all configurations

## Testing
- `git status --short`